### PR TITLE
Fix issue 7: handling different memberships api responses

### DIFF
--- a/src/mijnbib/mijnbibliotheek.py
+++ b/src/mijnbib/mijnbibliotheek.py
@@ -418,7 +418,7 @@ def _parse_api_memberships(memberships_data: dict) -> list[dict]:
             region = provider["region"]
             for _rijksregisternr, memberships in region.items():
                 membership_list.extend(memberships)
-        elif "library" in provider:
+        elif "library" in provider and isinstance(provider["library"], list):
             # StructureB: {"library": [Membership]}
             membership_list.extend(provider["library"])
     return membership_list

--- a/src/mijnbib/mijnbibliotheek.py
+++ b/src/mijnbib/mijnbibliotheek.py
@@ -421,6 +421,12 @@ def _parse_api_memberships(memberships_data: dict) -> list[dict]:
         elif "library" in provider and isinstance(provider["library"], list):
             # StructureB: {"library": [Membership]}
             membership_list.extend(provider["library"])
+        else:
+            raise IncompatibleSourceError(
+                f"Unexpected membership structure for provider '{_region_name}'. "
+                "Expected 'region' or 'library' key.",
+                html_body=str(provider),
+            )
     return membership_list
 
 

--- a/src/mijnbib/mijnbibliotheek.py
+++ b/src/mijnbib/mijnbibliotheek.py
@@ -405,11 +405,22 @@ class MijnBibliotheek:
 
 
 def _parse_api_memberships(memberships_data: dict) -> list[dict]:
+    """Parse memberships from the API response.
+
+    The API returns two different structures depending on the library system:
+    - StructureA (regio-bibs): {"region": { PersonId: [Membership] }}
+    - StructureB (traditional): {"library": [Membership]}
+    """
     membership_list = []
     for _region_name, provider in memberships_data.items():
-        region = provider["region"]
-        for _rijksregisternr, memberships in region.items():
-            membership_list.extend(memberships)
+        if "region" in provider:
+            # StructureA: {"region": { PersonId: [Membership] }}
+            region = provider["region"]
+            for _rijksregisternr, memberships in region.items():
+                membership_list.extend(memberships)
+        elif "library" in provider:
+            # StructureB: {"library": [Membership]}
+            membership_list.extend(provider["library"])
     return membership_list
 
 

--- a/tests/test_mijnbibliotheek.py
+++ b/tests/test_mijnbibliotheek.py
@@ -362,6 +362,36 @@ class TestGetAccounts:
         with pytest.raises(IncompatibleSourceError, match=r".*JSONDecodeError.*"):
             _accounts = mb.get_accounts()
 
+    def test_get_accounts_raises_incompatiblesource_error_on_unexpected_provider_structure(
+        self, requests_mock
+    ):
+        """Test that IncompatibleSourceError is raised when provider has neither 'region' nor 'library' key."""
+        mb = MijnBibliotheek("user", "pwd")
+        mb._logged_in = True  # fake logged in
+        requests_mock.get(
+            "https://bibliotheek.be/api/my-library/memberships",
+            text="""
+                {
+                  "UnknownProvider": {
+                    "unexpected_key": [
+                      {
+                        "hasError": false,
+                        "id": "123456",
+                        "libraryName": "Some Library",
+                        "name": "John Doe"
+                      }
+                    ]
+                  }
+                }
+                """,
+        )
+
+        with pytest.raises(
+            IncompatibleSourceError,
+            match=r".*Unexpected membership structure for provider 'UnknownProvider'.*",
+        ):
+            _accounts = mb.get_accounts()
+
 
 @pytest.mark.real
 @pytest.mark.skipif(

--- a/tests/test_mijnbibliotheek.py
+++ b/tests/test_mijnbibliotheek.py
@@ -223,6 +223,64 @@ class TestGetAccounts:
             open_amounts_url="https://bibliotheek.be/mijn-bibliotheek/lidmaatschappen/111222/te-betalen",
         )
 
+    def test_get_accounts_with_library_format(self, requests_mock):
+        """Test StructureB format: {"library": [Membership]} (non-regio-bibs).
+
+        See https://github.com/wvanhed/mijnbib/issues/7
+        """
+        mb = MijnBibliotheek("user", "pwd")
+        mb._logged_in = True  # fake logged in
+        requests_mock.get(
+            "https://bibliotheek.be/mijn-bibliotheek/aanmelden?destination=/mijn-bibliotheek/lidmaatschappen",
+            text="doesn't matter what is here",
+        )
+        requests_mock.get(
+            "https://bibliotheek.be/api/my-library/memberships",
+            text="""
+                {
+                  "SomeLibrary": {
+                    "library": [
+                      {
+                        "hasError": false,
+                        "id": "987654",
+                        "isBlocked": false,
+                        "isExpired": false,
+                        "libraryName": "Bibliotheek Leuven",
+                        "library": "https://leuven.bibliotheek.be",
+                        "name": "Alice Test"
+                      }
+                    ]
+                  }
+                }
+                """,
+        )
+        requests_mock.get(
+            "https://bibliotheek.be/api/my-library/987654/activities",
+            text="""
+                    {
+                    "loanHistoryUrl": "/mijn-bibliotheek/lidmaatschappen/987654/leenhistoriek",
+                    "numberOfHolds": 1,
+                    "numberOfLoans": 3,
+                    "openAmount": "0,00"
+                    }
+                """,
+        )
+
+        accounts = mb.get_accounts()
+
+        assert len(accounts) == 1
+        assert accounts[0] == Account(
+            library_name="Bibliotheek Leuven",
+            id="987654",
+            user="Alice Test",
+            open_amounts=0.0,
+            loans_count=3,
+            reservations_count=1,
+            loans_url="https://bibliotheek.be/mijn-bibliotheek/lidmaatschappen/987654/uitleningen",
+            reservations_url="https://bibliotheek.be/mijn-bibliotheek/lidmaatschappen/987654/reservaties",
+            open_amounts_url="https://bibliotheek.be/mijn-bibliotheek/lidmaatschappen/987654/te-betalen",
+        )
+
     def test_get_accounts_raises_incompatiblesource_error_on_unexpected_json_for_memberships(
         self, requests_mock
     ):

--- a/tests/test_mijnbibliotheek.py
+++ b/tests/test_mijnbibliotheek.py
@@ -245,8 +245,8 @@ class TestGetAccounts:
                         "id": "987654",
                         "isBlocked": false,
                         "isExpired": false,
-                        "libraryName": "Bibliotheek Leuven",
-                        "library": "https://leuven.bibliotheek.be",
+                        "libraryName": "Bibliotheek ABC",
+                        "library": "https://abc.bibliotheek.be",
                         "name": "Alice Test"
                       }
                     ]
@@ -270,7 +270,7 @@ class TestGetAccounts:
 
         assert len(accounts) == 1
         assert accounts[0] == Account(
-            library_name="Bibliotheek Leuven",
+            library_name="Bibliotheek ABC",
             id="987654",
             user="Alice Test",
             open_amounts=0.0,


### PR DESCRIPTION
Fix (hopefully) for issue #7 that reports that the json response of the memberships api might be different in some cases.

Waiting for fix confirmation from the poster of issue #7.